### PR TITLE
No events after destroy()

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ function RPC (opts) {
   }
 
   function onmessage (buf, rinfo) {
+    if (this.destroyed) return
     try {
       var message = bencode.decode(buf)
     } catch (e) {


### PR DESCRIPTION
It seems that it’s possible for ‘message’ events to arrive on the
socket even after socket.close() is called. I guess this is why we have
a ‘close’ event.

Still, I think we should suppress messages that arrive after destroy()
was called.

This surfaced in a webtorrent issue:
https://github.com/feross/webtorrent/issues/589
