### PR TITLE
Add IPv6 DHT support

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function RPC (opts) {
   this.destroyed = false
   this.ipv6 = !!opts.ipv6
   this.isIP = opts.isIP || (this.ipv6 ? net.isIPv6 : net.isIPv4)
-  this.socket = opts.socket || dgram.createSocket(this.ipv6 ? "udp6" : "udp4")
+  this.socket = opts.socket || dgram.createSocket(this.ipv6 ? 'udp6' : 'udp4')
   this.socket.on('message', onmessage)
   this.socket.on('error', onerror)
   this.socket.on('listening', onlistening)
@@ -202,7 +202,7 @@ RPC.prototype._cancel = function (index, err) {
 
 RPC.prototype.checkHostProtocol = function (host) {
   if ((this.ipv6 && net.isIPv4(host)) || (!this.ipv6 && net.isIPv6(host))) {
-    throw new Error("Address protocol mismatch! Expected an " + (this.ipv6 ? "IPv6" : "IPv4") + " address, but '" + host + "' was provided")
+    throw new Error('Address protocol mismatch! Expected an ' + (this.ipv6 ? 'IPv6' : 'IPv4') + " address, but '" + host + "' was provided")
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var dgram = require('dgram')
 var bencode = require('bencode')
-var isIP = require('net').isIP
+var net = require('net')
 var dns = require('dns')
 var util = require('util')
 var events = require('events')
@@ -19,8 +19,9 @@ function RPC (opts) {
   this.timeout = opts.timeout || 2000
   this.inflight = 0
   this.destroyed = false
-  this.isIP = opts.isIP || isIP
-  this.socket = opts.socket || dgram.createSocket('udp4')
+  this.ipv6 = !!opts.ipv6
+  this.isIP = opts.isIP || (this.ipv6 ? net.isIPv6 : net.isIPv4)
+  this.socket = opts.socket || dgram.createSocket(this.ipv6 ? "udp6" : "udp4")
   this.socket.on('message', onmessage)
   this.socket.on('error', onerror)
   this.socket.on('listening', onlistening)
@@ -178,6 +179,10 @@ RPC.prototype.query = function (peer, query, cb) {
   return tid
 }
 
+RPC.prototype.matches = function (peer) {
+  return this.isIP(peer.address || peer.host)
+}
+
 RPC.prototype.cancel = function (tid, err) {
   var index = this._ids.indexOf(tid)
   if (index > -1) this._cancel(index, err)
@@ -198,7 +203,7 @@ RPC.prototype._cancel = function (index, err) {
 RPC.prototype._resolveAndQuery = function (peer, query, cb) {
   var self = this
 
-  dns.lookup(peer.host, function (err, ip) {
+  dns.lookup(peer.host, self.ipv6 ? 6 : 4, function (err, ip) {
     if (err) return cb(err)
     if (self.destroyed) return cb(new Error('k-rpc-socket is destroyed'))
     self.query({host: ip, port: peer.port}, query, cb)

--- a/index.js
+++ b/index.js
@@ -200,8 +200,16 @@ RPC.prototype._cancel = function (index, err) {
   }
 }
 
+RPC.prototype.checkHostProtocol = function (host) {
+  if ((this.ipv6 && net.isIPv4(host)) || (!this.ipv6 && net.isIPv6(host))) {
+    throw new Error("Address protocol mismatch! Expected an " + (this.ipv6 ? "IPv6" : "IPv4") + " address, but '" + host + "' was provided")
+  }
+}
+
 RPC.prototype._resolveAndQuery = function (peer, query, cb) {
   var self = this
+
+  this.checkHostProtocol(peer.host)
 
   dns.lookup(peer.host, self.ipv6 ? 6 : 4, function (err, ip) {
     if (err) return cb(err)

--- a/test.js
+++ b/test.js
@@ -1,14 +1,6 @@
 var tape = require('tape')
 var rpc = require('./')
 
-tape('ipv4 query + response', function (t) {
-  genericQuery(t, {}, '127.0.0.1')
-})
-
-tape('ipv6 query + response', function (t) {
-  genericQuery(t, {ipv6: true}, '::1')
-})
-
 wrapTest(tape, 'query + response', function(t, ipv6) {
   var server = rpc({ipv6: ipv6})
   var address = localHost(ipv6, true)
@@ -24,7 +16,7 @@ wrapTest(tape, 'query + response', function(t, ipv6) {
 
   server.bind(0, function () {
     var port = server.address().port
-    var client = rpc(opts)
+    var client = rpc({ipv6: ipv6})
     t.same(client.inflight, 0)
     client.query({host: address, port: port}, {q: 'hello_world', a: {hej: 10}}, function (err, res) {
       t.same(client.inflight, 0)
@@ -48,7 +40,7 @@ wrapTest(tape, 'parallel query', function (t, ipv6) {
 
   server.bind(0, function () {
     var port = server.address().port
-    var client = rpc()
+    var client = rpc({ipv6: ipv6})
     var peer = {host: localHost(ipv6, true), port: port}
 
     client.query(peer, {q: 'echo', a: 1}, function (_, res) {
@@ -80,7 +72,7 @@ wrapTest(tape, 'query + error', function (t, ipv6) {
 
   server.bind(0, function () {
     var port = server.address().port
-    var client = rpc()
+    var client = rpc({ipv6: ipv6})
     client.query({host: localHost(ipv6, true), port: port}, {q: 'hello_world', a: {hej: 10}}, function (err) {
       client.destroy()
       server.destroy()

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 var tape = require('tape')
 var rpc = require('./')
 
-wrapTest(tape, 'query + response', function(t, ipv6) {
+wrapTest(tape, 'query + response', function (t, ipv6) {
   var server = rpc({ipv6: ipv6})
   var address = localHost(ipv6, true)
   var queried = false
@@ -94,7 +94,7 @@ wrapTest(tape, 'timeout', function (t, ipv6) {
   })
 })
 
-function localHost(ipv6, plainIpv6) {
+function localHost (ipv6, plainIpv6) {
   if (ipv6) {
     if (!plainIpv6) {
       return '[::1]'
@@ -104,7 +104,7 @@ function localHost(ipv6, plainIpv6) {
   return '127.0.0.1'
 }
 
-function wrapTest(test, str, func) {
+function wrapTest (test, str, func) {
   test('ipv4 ' + str, function (t) {
     func(t, false)
     if (t._plan) {


### PR DESCRIPTION
k-rpc-socket | [k-rpc](https://github.com/mafintosh/k-rpc/pull/5) | [bittorrent-dht](https://github.com/feross/bittorrent-dht/pull/144) | [torrent-discovery](https://github.com/feross/torrent-discovery/pull/27) | [webtorrent](https://github.com/feross/webtorrent/pull/950)

This is one of many pull requests across the WebTorrent ecosystem to add IPv6 DHT support, as per https://github.com/feross/bittorrent-dht/issues/88

Per [the BEP 32 statement about maintaining distinct IPv4/IPv6 DHTs](http://www.bittorrent.org/beps/bep_0032.html#operation) and the discussion on https://github.com/feross/bittorrent-dht/issues/88, my implementation requires separate instances of `bittorrent-dht` and everything below it on the protocol stack (`k-rpc` and `k-rpc-socket`). `torrent-discovery` maintains up to two `DHT` instances, one for each IP version used. Fortunately, WebTorrent already supports IPv6 peers, so no changes are needed in it beyond properly using the IPv6 DHT, if enabled in the options.

The best way to run all of my changes is by using the [npm link](https://docs.npmjs.com/cli/link) command. Assuming that all of the necessary modules (`k-rpc-socket`, `k-rpc`, `bittorrent-dht`, `torrent-discovery`, `webtorrent`, and `webtorrent-cli` are sibling directories, the following commands will set things up properly (starting from the parent directory):

```
cd k-rpc-socket
npm install
npm link
cd ../k-rpc
npm install
npm link k-rpc-socket
npm link
cd ../bittorrent-dht
npm install
npm link k-rpc
npm link
cd ../torrent-discovery
npm install
npm link bittorrent-dht
npm link
cd ../webtorrent
npm install
npm link bittorrent-dht
npm link torrent-discovery
npm link
cd ../webtorrent-cli
npm install
npm link webtorrent
```

From there, you can test and run individual modules as you choose.

---

**k-rpc-socket** specific notes:

This PR is fairly straightforward - I add an `ipv6` option to the `options` object, which controls whether the created socket will use an `IPv4` or `IPv6` UDP socket. I've also updated the tests to test both an IPv4 and IPv4 `RPC` object, using a wrapper function around the `tape` library.

TODO:
- [ ] Update the docs in the README. I've held off doing this in case people want me to modify the public-facing API additions I've made.

Caveats:
- The function `wrapTest` uses an internal `tape` variable: `_plan`. This was the most straightforward way to allow wrapping tests with minimal modifications, while ensuring that the `IPv4` and `IPv6` versions of a test do not run concurrently. If this is deemed to prone to breakage, I can investigate an alternate way of implementing `wrapTest`
- The two utility functions I add are common to almost all of my IPv6 DHT PRs, but I didn't think that they were large enough to warrant their own module. However, if we anticipate needing to share more code in order to properly test IPv6 DHT support, factoring them out might be worthwhile.
- The only reason that this PR has several commits is to help me keep track of the changes that I've made. If this PR is deemed mergeable after review, I can squash them into one.
