### PR TITLE
Make rounding easier to read

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function RPC (opts) {
   this._tick = 0
   this._ids = []
   this._reqs = []
-  this._timer = setInterval(check, (this.timeout / 4) | 0)
+  this._timer = setInterval(check, Math.floor(this.timeout / 4))
 
   events.EventEmitter.call(this)
 


### PR DESCRIPTION
`thing | 0` is just a more tricky way to write `Math.floor(thing)` and reduces readability