### PR TITLE
Update bencode

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Low level implementation of the k-rpc network layer that the BitTorrent DHT uses",
   "main": "index.js",
   "dependencies": {
-    "bencode": "^1.0.0",
+    "bencode": "^2.0.0",
     "buffer-equals": "^1.0.4",
     "safe-buffer": "^5.1.1"
   },


### PR DESCRIPTION
Library got an update recently: https://github.com/themasch/node-bencode/releases/tag/2.0.0
And `bittorrent-dht` already uses newer version, would be nice to have it here too so that browserify build doesn't get unnecessary larger.