### PR TITLE
Add "chromeapp" field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,14 @@
   "version": "1.9.0",
   "description": "Low level implementation of the k-rpc network layer that the BitTorrent DHT uses",
   "main": "index.js",
+  "chromeapp": {
+    "dgram": "chrome-dgram",
+    "net": "chrome-net"
+  },
   "dependencies": {
-    "bencode": "^2.0.0"
+    "bencode": "^2.0.0",
+    "chrome-dgram": "^3.0.2",
+    "chrome-net": "^3.3.2"
   },
   "devDependencies": {
     "standard": "*",


### PR DESCRIPTION
I'm attempting to make a defacto standard for specifying Chrome App dependency substitutions using the `"chromeapp"` field in `package.json`.

The `"chromeapp"` field is just like the [`"browser"` field in `package.json`](https://github.com/defunctzombie/package-browser-field-spec) except it's intended for Chrome Apps instead of a generic browser environment. Bundler tools like `browserify` or `webpack` can be configured to look for the `"chromeapp"` field instead of the `"browser"` field when doing a build for a Chrome App.

In this specific package, since Chrome Apps can use raw sockets we want to replace e.g. `require('net')` with `require('chrome-net')`.