### PR TITLE
breaking, fix, perf: ESM, drop buffer, modernize

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ npm install k-rpc-socket
 ## Usage
 
 ``` js
-var rpc = require('k-rpc-socket')
+import rpc from 'k-rpc-socket'
 
-var socket = rpc()
+const socket = rpc()
 
 socket.on('query', function (query, peer) {
   socket.response(peer, query, {echo: query.a})
 })
 
 socket.bind(10000, function () {
-  var anotherSocket = rpc()
+  const anotherSocket = rpc()
   anotherSocket.query({host: '127.0.0.1', port: 10000}, {q: 'echo', a: {hello: 'world'}}, function (err, response) {
     console.log(response.r) // prints {echo: {hello: Buffer('world')}}
   })
@@ -30,7 +30,7 @@ socket.bind(10000, function () {
 
 ## API
 
-#### `var socket = rpc([options])`
+#### `const socket = rpc([options])`
 
 Create a new k-rpc-socket. Options include:
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ npm install k-rpc-socket
 ## Usage
 
 ``` js
-import rpc from 'k-rpc-socket'
+import RPC from 'k-rpc-socket'
 
-const socket = rpc()
+const socket = new RPC()
 
 socket.on('query', function (query, peer) {
   socket.response(peer, query, {echo: query.a})
 })
 
 socket.bind(10000, function () {
-  const anotherSocket = rpc()
+  const anotherSocket = new RPC()
   anotherSocket.query({host: '127.0.0.1', port: 10000}, {q: 'echo', a: {hello: 'world'}}, function (err, response) {
     console.log(response.r) // prints {echo: {hello: Buffer('world')}}
   })
@@ -30,7 +30,7 @@ socket.bind(10000, function () {
 
 ## API
 
-#### `const socket = rpc([options])`
+#### `const socket = new RPC([options])`
 
 Create a new k-rpc-socket. Options include:
 
@@ -46,7 +46,7 @@ Create a new k-rpc-socket. Options include:
 
 Send a raw message. The callback is called when the message has been flushed from the socket.
 
-#### `var id = socket.query(peer, query, [callback])`
+#### `const id = socket.query(peer, query, [callback])`
 
 Send a query message. The callback is called with `(err, response, peer, request)`.
 You should set the method name you are trying to call as `{q: 'method_name'}` and query data as `{a: someQueryData}`.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ import dgram from 'dgram'
 import bencode from 'bencode'
 import { isIP } from 'net'
 import dns from 'dns'
-import util from 'util'
 import { EventEmitter } from 'events'
 import { arr2text } from 'uint8-util'
 
@@ -12,213 +11,209 @@ ETIMEDOUT.code = 'ETIMEDOUT'
 const EUNEXPECTEDNODE = new Error('Unexpected node id')
 EUNEXPECTEDNODE.code = 'EUNEXPECTEDNODE'
 
-export default function RPC (opts) {
-  if (!(this instanceof RPC)) return new RPC(opts)
-  if (!opts) opts = {}
+export default class RPC extends EventEmitter {
+  constructor (opts = {}) {
+    super()
+    const self = this
 
-  const self = this
+    this.timeout = opts.timeout || 2000
+    this.inflight = 0
+    this.destroyed = false
+    this.isIP = opts.isIP || isIP
+    this.socket = opts.socket || dgram.createSocket('udp4')
+    this.socket.on('message', onmessage)
+    this.socket.on('error', onerror)
+    this.socket.on('listening', onlistening)
 
-  this.timeout = opts.timeout || 2000
-  this.inflight = 0
-  this.destroyed = false
-  this.isIP = opts.isIP || isIP
-  this.socket = opts.socket || dgram.createSocket('udp4')
-  this.socket.on('message', onmessage)
-  this.socket.on('error', onerror)
-  this.socket.on('listening', onlistening)
+    this._tick = 0
+    this._ids = []
+    this._reqs = []
+    this._timer = setInterval(check, Math.floor(this.timeout / 4))
 
-  this._tick = 0
-  this._ids = []
-  this._reqs = []
-  this._timer = setInterval(check, Math.floor(this.timeout / 4))
-
-  EventEmitter.call(this)
-
-  function check () {
-    let missing = self.inflight
-    if (!missing) return
-    for (let i = 0; i < self._reqs.length; i++) {
-      const req = self._reqs[i]
-      if (!req) continue
-      if (req.ttl) req.ttl--
-      else self._cancel(i, ETIMEDOUT)
-      if (!--missing) return
-    }
-  }
-
-  function onlistening () {
-    self.emit('listening')
-  }
-
-  function onerror (err) {
-    if (err.code === 'EACCES' || err.code === 'EADDRINUSE') self.emit('error', err)
-    else self.emit('warning', err)
-  }
-
-  function onmessage (buf, rinfo) {
-    if (self.destroyed) return
-    if (!rinfo.port) return // seems like a node bug that this is nessesary?
-
-    let message = null
-    try {
-      message = bencode.decode(buf)
-    } catch (e) {
-      return self.emit('warning', e)
+    function check () {
+      let missing = self.inflight
+      if (!missing) return
+      for (let i = 0; i < self._reqs.length; i++) {
+        const req = self._reqs[i]
+        if (!req) continue
+        if (req.ttl) req.ttl--
+        else self._cancel(i, ETIMEDOUT)
+        if (!--missing) return
+      }
     }
 
-    const type = message && message.y && arr2text(message.y)
+    function onlistening () {
+      self.emit('listening')
+    }
 
-    if (type === 'r' || type === 'e') {
-      if (!ArrayBuffer.isView(message.t)) return
+    function onerror (err) {
+      if (err.code === 'EACCES' || err.code === 'EADDRINUSE') self.emit('error', err)
+      else self.emit('warning', err)
+    }
 
-      let tid = null
+    function onmessage (buf, rinfo) {
+      if (self.destroyed) return
+      if (!rinfo.port) return // seems like a node bug that this is nessesary?
+
+      let message = null
       try {
-        const view = new DataView(message.t.buffer)
-        tid = view.getUint16(0)
-      } catch (err) {
-        return self.emit('warning', err)
+        message = bencode.decode(buf)
+      } catch (e) {
+        return self.emit('warning', e)
       }
 
-      const index = self._ids.indexOf(tid)
-      if (index === -1 || tid === 0) {
-        self.emit('response', message, rinfo)
-        self.emit('warning', new Error('Unexpected transaction id: ' + tid))
-        return
-      }
+      const type = message && message.y && arr2text(message.y)
 
-      const req = self._reqs[index]
-      if (req.peer.host !== rinfo.address) {
-        self.emit('response', message, rinfo)
-        self.emit('warning', new Error('Out of order response'))
-        return
-      }
+      if (type === 'r' || type === 'e') {
+        if (!ArrayBuffer.isView(message.t)) return
 
-      self._ids[index] = 0
-      self._reqs[index] = null
-      self.inflight--
+        let tid = null
+        try {
+          const view = new DataView(message.t.buffer)
+          tid = view.getUint16(0)
+        } catch (err) {
+          return self.emit('warning', err)
+        }
 
-      if (type === 'e') {
-        const isArray = Array.isArray(message.e)
-        if (isArray) message.e = message.e.map(e => ArrayBuffer.isView(e) ? arr2text(e) : e)
-        const err = new Error(isArray ? message.e.join(' ') : 'Unknown error')
-        err.code = isArray && message.e.length && typeof message.e[0] === 'number' ? message.e[0] : 0
-        req.callback(err, message, rinfo, req.message)
+        const index = self._ids.indexOf(tid)
+        if (index === -1 || tid === 0) {
+          self.emit('response', message, rinfo)
+          self.emit('warning', new Error('Unexpected transaction id: ' + tid))
+          return
+        }
+
+        const req = self._reqs[index]
+        if (req.peer.host !== rinfo.address) {
+          self.emit('response', message, rinfo)
+          self.emit('warning', new Error('Out of order response'))
+          return
+        }
+
+        self._ids[index] = 0
+        self._reqs[index] = null
+        self.inflight--
+
+        if (type === 'e') {
+          const isArray = Array.isArray(message.e)
+          if (isArray) message.e = message.e.map(e => ArrayBuffer.isView(e) ? arr2text(e) : e)
+          const err = new Error(isArray ? message.e.join(' ') : 'Unknown error')
+          err.code = isArray && message.e.length && typeof message.e[0] === 'number' ? message.e[0] : 0
+          req.callback(err, message, rinfo, req.message)
+          self.emit('update')
+          self.emit('postupdate')
+          return
+        }
+
+        const rid = message.r && message.r.id
+        if (req.peer && req.peer.id && rid && !req.peer.id.equals(rid)) {
+          req.callback(EUNEXPECTEDNODE, null, rinfo)
+          self.emit('update')
+          self.emit('postupdate')
+          return
+        }
+
+        req.callback(null, message, rinfo, req.message)
         self.emit('update')
         self.emit('postupdate')
-        return
+        self.emit('response', message, rinfo)
+      } else if (type === 'q') {
+        self.emit('query', message, rinfo)
+      } else {
+        self.emit('warning', new Error('Unknown type: ' + type))
       }
-
-      const rid = message.r && message.r.id
-      if (req.peer && req.peer.id && rid && !req.peer.id.equals(rid)) {
-        req.callback(EUNEXPECTEDNODE, null, rinfo)
-        self.emit('update')
-        self.emit('postupdate')
-        return
-      }
-
-      req.callback(null, message, rinfo, req.message)
-      self.emit('update')
-      self.emit('postupdate')
-      self.emit('response', message, rinfo)
-    } else if (type === 'q') {
-      self.emit('query', message, rinfo)
-    } else {
-      self.emit('warning', new Error('Unknown type: ' + type))
     }
   }
-}
 
-util.inherits(RPC, EventEmitter)
-
-RPC.prototype.address = function () {
-  return this.socket.address()
-}
-
-RPC.prototype.response = function (peer, req, res, cb) {
-  this.send(peer, { t: req.t, y: 'r', r: res }, cb)
-}
-
-RPC.prototype.error = function (peer, req, error, cb) {
-  this.send(peer, { t: req.t, y: 'e', e: [].concat(error.message || error) }, cb)
-}
-
-RPC.prototype.send = function (peer, message, cb) {
-  const buf = bencode.encode(message)
-  this.socket.send(buf, 0, buf.length, peer.port, peer.address || peer.host, cb || noop)
-}
-
-// bind([port], [address], [callback])
-RPC.prototype.bind = function () {
-  this.socket.bind.apply(this.socket, arguments)
-}
-
-RPC.prototype.destroy = function (cb) {
-  this.destroyed = true
-  clearInterval(this._timer)
-  if (cb) this.socket.on('close', cb)
-  for (let i = 0; i < this._ids.length; i++) this._cancel(i)
-  this.socket.close()
-}
-
-RPC.prototype.query = function (peer, query, cb) {
-  if (!cb) cb = noop
-  if (!this.isIP(peer.host)) return this._resolveAndQuery(peer, query, cb)
-
-  const message = {
-    t: new Uint8Array(2),
-    y: 'q',
-    q: query.q,
-    a: query.a
+  address () {
+    return this.socket.address()
   }
 
-  const req = {
-    ttl: 4,
-    peer,
-    message,
-    callback: cb
+  response (peer, req, res, cb) {
+    this.send(peer, { t: req.t, y: 'r', r: res }, cb)
   }
 
-  if (this._tick === 65535) this._tick = 0
-  const tid = ++this._tick
-
-  let free = this._ids.indexOf(0)
-  if (free === -1) free = this._ids.push(0) - 1
-  this._ids[free] = tid
-  while (this._reqs.length < free) this._reqs.push(null)
-  this._reqs[free] = req
-
-  this.inflight++
-  const view = new DataView(message.t.buffer)
-  view.setUint16(0, tid)
-  this.send(peer, message)
-  return tid
-}
-
-RPC.prototype.cancel = function (tid, err) {
-  const index = this._ids.indexOf(tid)
-  if (index > -1) this._cancel(index, err)
-}
-
-RPC.prototype._cancel = function (index, err) {
-  const req = this._reqs[index]
-  this._ids[index] = 0
-  this._reqs[index] = null
-  if (req) {
-    this.inflight--
-    req.callback(err || new Error('Query was cancelled'), null, req.peer)
-    this.emit('update')
-    this.emit('postupdate')
+  error (peer, req, error, cb) {
+    this.send(peer, { t: req.t, y: 'e', e: [].concat(error.message || error) }, cb)
   }
-}
 
-RPC.prototype._resolveAndQuery = function (peer, query, cb) {
-  const self = this
+  send (peer, message, cb) {
+    const buf = bencode.encode(message)
+    this.socket.send(buf, 0, buf.length, peer.port, peer.address || peer.host, cb || noop)
+  }
 
-  dns.lookup(peer.host, function (err, ip) {
-    if (err) return cb(err)
-    if (self.destroyed) return cb(new Error('k-rpc-socket is destroyed'))
-    self.query({ host: ip, port: peer.port }, query, cb)
-  })
+  // bind([port], [address], [callback])
+  bind () {
+    this.socket.bind.apply(this.socket, arguments)
+  }
+
+  destroy (cb) {
+    this.destroyed = true
+    clearInterval(this._timer)
+    if (cb) this.socket.on('close', cb)
+    for (let i = 0; i < this._ids.length; i++) this._cancel(i)
+    this.socket.close()
+  }
+
+  query (peer, query, cb) {
+    if (!cb) cb = noop
+    if (!this.isIP(peer.host)) return this._resolveAndQuery(peer, query, cb)
+
+    const message = {
+      t: new Uint8Array(2),
+      y: 'q',
+      q: query.q,
+      a: query.a
+    }
+
+    const req = {
+      ttl: 4,
+      peer,
+      message,
+      callback: cb
+    }
+
+    if (this._tick === 65535) this._tick = 0
+    const tid = ++this._tick
+
+    let free = this._ids.indexOf(0)
+    if (free === -1) free = this._ids.push(0) - 1
+    this._ids[free] = tid
+    while (this._reqs.length < free) this._reqs.push(null)
+    this._reqs[free] = req
+
+    this.inflight++
+    const view = new DataView(message.t.buffer)
+    view.setUint16(0, tid)
+    this.send(peer, message)
+    return tid
+  }
+
+  cancel (tid, err) {
+    const index = this._ids.indexOf(tid)
+    if (index > -1) this._cancel(index, err)
+  }
+
+  _cancel (index, err) {
+    const req = this._reqs[index]
+    this._ids[index] = 0
+    this._reqs[index] = null
+    if (req) {
+      this.inflight--
+      req.callback(err || new Error('Query was cancelled'), null, req.peer)
+      this.emit('update')
+      this.emit('postupdate')
+    }
+  }
+
+  _resolveAndQuery (peer, query, cb) {
+    const self = this
+
+    dns.lookup(peer.host, function (err, ip) {
+      if (err) return cb(err)
+      if (self.destroyed) return cb(new Error('k-rpc-socket is destroyed'))
+      self.query({ host: ip, port: peer.port }, query, cb)
+    })
+  }
 }
 
 function noop () {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k-rpc-socket",
-  "version": "1.11.1",
+  "version": "2.0.0",
   "type": "module",
   "description": "Low level implementation of the k-rpc network layer that the BitTorrent DHT uses",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,22 +1,26 @@
 {
   "name": "k-rpc-socket",
   "version": "1.11.1",
+  "type": "module",
   "description": "Low level implementation of the k-rpc network layer that the BitTorrent DHT uses",
-  "main": "index.js",
+  "exports": {
+    "import": "./index.js"
+  },
   "chromeapp": {
     "dgram": "chrome-dgram",
     "dns": "chrome-dns",
     "net": "chrome-net"
   },
   "dependencies": {
-    "bencode": "^2.0.0",
-    "chrome-dgram": "^3.0.2",
-    "chrome-dns": "^1.0.0",
-    "chrome-net": "^3.3.2"
+    "bencode": "^3.0.3",
+    "chrome-dgram": "^3.0.6",
+    "chrome-dns": "^1.0.1",
+    "chrome-net": "^3.3.4",
+    "uint8-util": "^2.1.7"
   },
   "devDependencies": {
     "standard": "*",
-    "tape": "^4.4.0"
+    "tape": "^5.6.3"
   },
   "scripts": {
     "test": "standard && tape test.js"

--- a/test.js
+++ b/test.js
@@ -1,24 +1,24 @@
-var tape = require('tape')
-var rpc = require('./')
-var dgram = require('dgram')
+import tape from 'tape'
+import RPC from './index.js'
+import dgram from 'dgram'
 
 tape('query + response', function (t) {
-  var server = rpc()
-  var queried = false
+  const server = new RPC()
+  let queried = false
 
   server.on('query', function (query, peer) {
     queried = true
     t.same(peer.address, '127.0.0.1')
-    t.same(query.q.toString(), 'hello_world')
+    t.same(Buffer.from(query.q).toString(), 'hello_world')
     t.same(query.a, { hej: 10 })
     server.response(peer, query, { hello: 42 })
   })
 
-  server.bind(0, function () {
-    var port = server.address().port
-    var client = rpc()
+  server.bind(0, function (a) {
+    const port = server.address().port
+    const client = new RPC()
     t.same(client.inflight, 0)
-    client.query({ host: '127.0.0.1', port: port }, { q: 'hello_world', a: { hej: 10 } }, function (err, res) {
+    client.query({ host: '127.0.0.1', port }, { q: 'hello_world', a: { hej: 10 } }, function (err, res) {
       t.same(client.inflight, 0)
       server.destroy()
       client.destroy()
@@ -32,16 +32,16 @@ tape('query + response', function (t) {
 })
 
 tape('parallel query', function (t) {
-  var server = rpc()
+  const server = new RPC()
 
   server.on('query', function (query, peer) {
     server.response(peer, query, { echo: query.a })
   })
 
   server.bind(0, function () {
-    var port = server.address().port
-    var client = rpc()
-    var peer = { host: '127.0.0.1', port: port }
+    const port = server.address().port
+    const client = new RPC()
+    const peer = { host: '127.0.0.1', port }
 
     client.query(peer, { q: 'echo', a: 1 }, function (_, res) {
       t.same(res.r, { echo: 1 })
@@ -64,16 +64,16 @@ tape('parallel query', function (t) {
 })
 
 tape('query + error', function (t) {
-  var server = rpc()
+  const server = new RPC()
 
   server.on('query', function (query, peer) {
     server.error(peer, query, 'oh no')
   })
 
   server.bind(0, function () {
-    var port = server.address().port
-    var client = rpc()
-    client.query({ host: '127.0.0.1', port: port }, { q: 'hello_world', a: { hej: 10 } }, function (err) {
+    const port = server.address().port
+    const client = new RPC()
+    client.query({ host: '127.0.0.1', port }, { q: 'hello_world', a: { hej: 10 } }, function (err) {
       client.destroy()
       server.destroy()
       t.ok(err)
@@ -84,7 +84,7 @@ tape('query + error', function (t) {
 })
 
 tape('timeout', function (t) {
-  var socket = rpc({ timeout: 100 })
+  const socket = RPC({ timeout: 100 })
 
   socket.query({ host: 'example.com', port: 12345 }, { q: 'timeout' }, function (err) {
     socket.destroy()
@@ -101,8 +101,8 @@ tape('do not crash on empty string', function (t) {
     t.end()
     return
   }
-  var server = rpc()
-  var socket = dgram.createSocket('udp4')
+  const server = new RPC()
+  const socket = dgram.createSocket('udp4')
 
   server.on('query', function (query, peer) {
     t.fail('should not get a query')
@@ -116,7 +116,7 @@ tape('do not crash on empty string', function (t) {
   })
 
   server.bind(0, function () {
-    var port = server.address().port
+    const port = server.address().port
     socket.send('' /* invalid bencoded data */, 0, 0, port, '127.0.0.1')
   })
 })

--- a/test.js
+++ b/test.js
@@ -84,7 +84,7 @@ tape('query + error', function (t) {
 })
 
 tape('timeout', function (t) {
-  const socket = RPC({ timeout: 100 })
+  const socket = new RPC({ timeout: 100 })
 
   socket.query({ host: 'example.com', port: 12345 }, { q: 'timeout' }, function (err) {
     socket.destroy()


### PR DESCRIPTION
This PR modernizes this library, migrates to ESM, drops buffer and updates dependencies.

The git diff shows some crazy stuff, but in practice all that really changed is all the functions were moved into a class, `Buffer.isBuffer` was replaced with `ArrayBuffer.isView` and a few other tiny tweaks, dropped util.inherits and updated docs accordingly.

Doing this because webtorrent is updating it's dependencies to deprecate buffer, one of which is bencode, which also runs on the browser, even tho this package doesn't, and since the new bencode is ESM only this also needs to be ESM